### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,18 @@ find_package(apriltag 3.2 REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake REQUIRED)
 
+include_directories(include
+  ${EIGEN3_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
+)
+
 add_library(tags OBJECT src/tag_functions.cpp)
 target_link_libraries(tags apriltag::apriltag)
 set_property(TARGET tags PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(AprilTagNode SHARED src/AprilTagNode.cpp)
 ament_target_dependencies(AprilTagNode rclcpp rclcpp_components sensor_msgs apriltag_msgs tf2_ros image_transport cv_bridge)
-target_link_libraries(AprilTagNode apriltag::apriltag tags Eigen3::Eigen)
+target_link_libraries(AprilTagNode ${OpenCV_LIBRARIES} apriltag::apriltag tags Eigen3::Eigen)
 rclcpp_components_register_node(AprilTagNode PLUGIN "AprilTagNode" EXECUTABLE "apriltag_node")
 
 ament_environment_hooks(${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH})


### PR DESCRIPTION
Fixed issue with AprilTagNode potentially not being able to link to the OpenCV library, as manifested in the error below:

```
/usr/bin/ld: CMakeFiles/AprilTagNode.dir/src/AprilTagNode.cpp.o: in function `getRelativeTransform(std::vector<cv::Point3_<double>, std::allocator<cv::Point3_<double> > >, std::vector<cv::Point_<double>, std::allocator<cv::Point_<double> > >, cv::Matx<double, 3, 3>, cv::Vec<float, 5>)':
AprilTagNode.cpp:(.text+0xbd0): undefined reference to `cv::solvePnP(cv::_InputArray const&, cv::_InputArray const&, cv::_InputArray const&, cv::_InputArray const&, cv::_OutputArray const&, cv::_OutputArray const&, bool, int)'
/usr/bin/ld: AprilTagNode.cpp:(.text+0xc93): undefined reference to `cv::Rodrigues(cv::_InputArray const&, cv::_OutputArray const&, cv::_OutputArray const&)'
collect2: error: ld returned 1 exit status

```